### PR TITLE
Improves github integration

### DIFF
--- a/taiga/hooks/github/event_hooks.py
+++ b/taiga/hooks/github/event_hooks.py
@@ -1,7 +1,6 @@
-# Copyright (C) 2014-2016 Andrey Antukh <niwi@niwi.nz>
+# Copyright (C) 2014-2016 Andrey Antukh <niwi@niwi.be>
 # Copyright (C) 2014-2016 Jesús Espino <jespinog@gmail.com>
 # Copyright (C) 2014-2016 David Barragán <bameda@dbarragan.com>
-# Copyright (C) 2014-2016 Alejandro Alonso <alejandro.alonso@kaleidos.net>
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
 # published by the Free Software Foundation, either version 3 of the
@@ -123,9 +122,6 @@ def replace_github_references(project_url, wiki_text):
 
 class IssuesEventHook(BaseEventHook):
     def process_event(self):
-        if self.payload.get('action', None) != "opened":
-            return
-
         number = self.payload.get('issue', {}).get('number', None)
         subject = self.payload.get('issue', {}).get('title', None)
         github_url = self.payload.get('issue', {}).get('html_url', None)
@@ -141,6 +137,20 @@ class IssuesEventHook(BaseEventHook):
         if not all([subject, github_url, project_url]):
             raise ActionSyntaxException(_("Invalid issue information"))
 
+        if self.payload.get('action', None) == "opened":
+            _process_opened(self, number, subject, github_url, user, github_user_name, github_user_url, project_url, description)
+        if self.payload.get('action', None) == "edited":
+            _process_edited(number, subject, github_url, user, github_user_name, github_user_url, project_url, description)
+
+
+    def _process_edited(number, subject, github_url, github_user_id, github_user_name, github_user_url, project_url, description):
+        issues = Issue.objects.filter(external_reference=["github", github_url])
+
+        for item in list(issues):
+            return
+
+
+    def _process_opened(self, number, subject, github_url, github_user_id, github_user_name, github_user_url, project_url, description):
         issue = Issue.objects.create(
             project=self.project,
             subject=subject,

--- a/taiga/hooks/github/event_hooks.py
+++ b/taiga/hooks/github/event_hooks.py
@@ -212,7 +212,7 @@ class IssueCommentEventHook(BaseEventHook):
     def process_event(self):
         action = self.payload.get('action', None) 
 
-        if action != "created" and action != "edited" and action != "deleted" 
+        if action != "created" and action != "edited" and action != "deleted":
             raise ActionSyntaxException(_("Invalid issue comment information"))
 
         number = self.payload.get('issue', {}).get('number', None)

--- a/taiga/hooks/github/event_hooks.py
+++ b/taiga/hooks/github/event_hooks.py
@@ -252,7 +252,7 @@ class IssueCommentEventHook(BaseEventHook):
 
 
     def _process_edited(self, item, comment, comment_github_url):
-        histories = HistoryEntry.objects.filter(key="issues.issue:" + item.id, comment__contains=comment_github_url)
+        histories = HistoryEntry.objects.filter(key="issues.issue:" + str(item.id), comment__contains=comment_github_url)
         
         for history in list(histories):
             history.comment = comment

--- a/taiga/hooks/github/event_hooks.py
+++ b/taiga/hooks/github/event_hooks.py
@@ -154,27 +154,27 @@ class IssuesEventHook(BaseEventHook):
     def _process_edited(self, subject, github_url, user, description):
         issues = Issue.objects.filter(external_reference=["github", github_url])
 
-        for item in list(issues):
-            item.subject = subject
-            item.description = description
-            item.save()
+        for issue in list(issues):
+            issue.subject = subject
+            issue.description = description
+            issue.save()
 
-            snapshot = take_snapshot(item,
+            snapshot = take_snapshot(issue,
                                     comment="Status changed from GitHub.",
                                     user=user)
-            send_notifications(element, history=snapshot)
+            send_notifications(issue, history=snapshot)
 
     def _process_status_changed(self, github_url, user, status):
         issues = Issue.objects.filter(external_reference=["github", github_url])
 
-        for item in list(issues):
-            item.status = IssueStatus.objects.get(project=self.project, slug=status)
-            item.save()
+        for issue in list(issues):
+            issue.status = IssueStatus.objects.get(project=self.project, slug=status)
+            issue.save()
 
-            snapshot = take_snapshot(item,
+            snapshot = take_snapshot(issue,
                                     comment="Status changed from GitHub.",
                                     user=user)
-            send_notifications(element, history=snapshot)
+            send_notifications(issue, history=snapshot)
 
     def _process_opened(self, number, subject, github_url, user, github_user_name, github_user_url, project_url, description):
         issue = Issue.objects.create(
@@ -232,8 +232,8 @@ class IssueCommentEventHook(BaseEventHook):
             raise ActionSyntaxException(_("Invalid issue comment information"))
 
         issues = Issue.objects.filter(external_reference=["github", github_url])
-        # tasks = Task.objects.filter(external_reference=["github", github_url])
-        # uss = UserStory.objects.filter(external_reference=["github", github_url])
+        tasks = Task.objects.filter(external_reference=["github", github_url])
+        uss = UserStory.objects.filter(external_reference=["github", github_url])
 
         if number and subject and github_user_name and github_user_url:
             comment = _("Comment by [@{github_user_name}]({github_user_url} "

--- a/taiga/hooks/github/event_hooks.py
+++ b/taiga/hooks/github/event_hooks.py
@@ -158,7 +158,7 @@ class IssuesEventHook(BaseEventHook):
     def _process_labeled(self, user, github_url):
         issues = Issue.objects.filter(external_reference=["github", github_url])
         
-        labels = [x.name for x in list(self.payload.get('labels', []))]
+        labels = [x['name'] for x in list(self.payload.get('labels', []))]
 
         # (Testar) pesquisar os tipos dos issues pelo nome dos labels e trazer o primeiro ordenado pelo order crescente 
         issueType = IssueType.objects.filter(project=self.project, name__in=labels).order_by('order').first()

--- a/taiga/hooks/github/event_hooks.py
+++ b/taiga/hooks/github/event_hooks.py
@@ -157,7 +157,7 @@ class IssuesEventHook(BaseEventHook):
 
     def _process_labeled(self, user, github_url):
         issues = Issue.objects.filter(external_reference=["github", github_url])
-        l = list(self.payload.labels)
+        l = list(self.payload['labels'])
 
         raise ActionSyntaxException(str(l))
 

--- a/taiga/hooks/github/event_hooks.py
+++ b/taiga/hooks/github/event_hooks.py
@@ -163,11 +163,11 @@ class IssuesEventHook(BaseEventHook):
         # (Testar) pesquisar os tipos dos issues pelo nome dos labels e trazer o primeiro ordenado pelo order crescente 
         issueType = IssueType.objects.filter(project=self.project, name__in=labels).order_by('order').first()
 
-        print '\nIssuetype:' + issueType.name
+        print ('\nIssuetype:' + issueType.name)
 
-        print str(labels)
+        print (str(labels))
 
-        print labels
+        print (labels)
 
         for issue in list(issues):
             issue.tags = labels # pesquisar como salvar tags (Testar) 

--- a/taiga/hooks/github/event_hooks.py
+++ b/taiga/hooks/github/event_hooks.py
@@ -163,11 +163,15 @@ class IssuesEventHook(BaseEventHook):
         # (Testar) pesquisar os tipos dos issues pelo nome dos labels e trazer o primeiro ordenado pelo order crescente 
         issueType = IssueType.objects.filter(project=self.project, name__in=labels).order_by('order').first()
 
-        print ('\nIssuetype:' + issueType.name)
+        # print ('\nIssuetype:' + issueType.name)
 
         print (str(labels))
 
         print (labels)
+
+        print (str(issueType))
+
+        print (issueType)
 
         for issue in list(issues):
             issue.tags = labels # pesquisar como salvar tags (Testar) 

--- a/taiga/hooks/github/event_hooks.py
+++ b/taiga/hooks/github/event_hooks.py
@@ -169,7 +169,7 @@ class IssuesEventHook(BaseEventHook):
                         "\"See @{github_user_name}'s GitHub profile\") "
                         "from GitHub.\nOrigin GitHub issue: [gh#{number} - {subject}]({github_url} "
                         "\"Go to 'gh#{number} - {subject}'\"):\n\n"
-                        "{description}").format(github_user_name=github_user_name,
+                        "{description}. CHANGED!").format(github_user_name=github_user_name,
                                                 github_user_url=github_user_url,
                                                 number=number,
                                                 subject=subject,

--- a/taiga/hooks/github/event_hooks.py
+++ b/taiga/hooks/github/event_hooks.py
@@ -212,7 +212,7 @@ class IssueCommentEventHook(BaseEventHook):
                             "\"See @{github_user_name}'s GitHub profile\") "
                             "from GitHub.\nOrigin GitHub issue: [gh#{number} - {subject}]({github_url} "
                             "\"Go to 'gh#{number} - {subject}'\")\n\n"
-                            "{message}").format(github_user_name=github_user_name,
+                            "{message}. CHANGED!").format(github_user_name=github_user_name,
                                                 github_user_url=github_user_url,
                                                 number=number,
                                                 subject=subject,

--- a/taiga/hooks/github/event_hooks.py
+++ b/taiga/hooks/github/event_hooks.py
@@ -269,7 +269,7 @@ class IssueCommentEventHook(BaseEventHook):
         else:
             comment = _("Comment From GitHub:\n\n{message}").format(message=comment_message)
 
-        for item in list(issues):# + list(tasks) + list(uss):
+        for item in list(issues) + list(tasks) + list(uss):
             if action == "created":
                 self._process_created(item, comment, user)
             elif action == "edited":

--- a/taiga/hooks/github/event_hooks.py
+++ b/taiga/hooks/github/event_hooks.py
@@ -138,15 +138,16 @@ class IssuesEventHook(BaseEventHook):
             raise ActionSyntaxException(_("Invalid issue information"))
 
         if self.payload.get('action', None) == "opened":
-            _process_opened(self, number, subject, github_url, user, github_user_name, github_user_url, project_url, description)
+            self._process_opened(self, number, subject, github_url, user, github_user_name, github_user_url, project_url, description)
         if self.payload.get('action', None) == "edited":
-            _process_edited(number, subject, github_url, user, github_user_name, github_user_url, project_url, description)
+            self._process_edited(number, subject, github_url, user, github_user_name, github_user_url, project_url, description)
 
 
-    def _process_edited(number, subject, github_url, github_user_id, github_user_name, github_user_url, project_url, description):
+    def _process_edited(self, number, subject, github_url, github_user_id, github_user_name, github_user_url, project_url, description):
         issues = Issue.objects.filter(external_reference=["github", github_url])
 
         for item in list(issues):
+
             return
 
 
@@ -169,7 +170,7 @@ class IssuesEventHook(BaseEventHook):
                         "\"See @{github_user_name}'s GitHub profile\") "
                         "from GitHub.\nOrigin GitHub issue: [gh#{number} - {subject}]({github_url} "
                         "\"Go to 'gh#{number} - {subject}'\"):\n\n"
-                        "{description}. CHANGED!").format(github_user_name=github_user_name,
+                        "{description}").format(github_user_name=github_user_name,
                                                 github_user_url=github_user_url,
                                                 number=number,
                                                 subject=subject,
@@ -212,7 +213,7 @@ class IssueCommentEventHook(BaseEventHook):
                             "\"See @{github_user_name}'s GitHub profile\") "
                             "from GitHub.\nOrigin GitHub issue: [gh#{number} - {subject}]({github_url} "
                             "\"Go to 'gh#{number} - {subject}'\")\n\n"
-                            "{message}. CHANGED!").format(github_user_name=github_user_name,
+                            "{message}").format(github_user_name=github_user_name,
                                                 github_user_url=github_user_url,
                                                 number=number,
                                                 subject=subject,

--- a/taiga/hooks/github/event_hooks.py
+++ b/taiga/hooks/github/event_hooks.py
@@ -160,7 +160,7 @@ class IssuesEventHook(BaseEventHook):
             issue.save()
 
             snapshot = take_snapshot(issue,
-                                    comment="Status changed from GitHub.",
+                                    comment="Edited from GitHub.",
                                     user=user)
             send_notifications(issue, history=snapshot)
 

--- a/taiga/hooks/github/event_hooks.py
+++ b/taiga/hooks/github/event_hooks.py
@@ -143,7 +143,7 @@ class IssuesEventHook(BaseEventHook):
             self._process_edited(number, subject, github_url, user, github_user_name, github_user_url, project_url, description)
 
 
-    def _process_edited(self, number, subject, github_url, github_user_id, github_user_name, github_user_url, project_url, description):
+    def _process_edited(self, number, subject, github_url, user, github_user_name, github_user_url, project_url, description):
         issues = Issue.objects.filter(external_reference=["github", github_url])
 
         for item in list(issues):
@@ -151,7 +151,7 @@ class IssuesEventHook(BaseEventHook):
             return
 
 
-    def _process_opened(self, number, subject, github_url, github_user_id, github_user_name, github_user_url, project_url, description):
+    def _process_opened(self, number, subject, github_url, user, github_user_name, github_user_url, project_url, description):
         issue = Issue.objects.create(
             project=self.project,
             subject=subject,

--- a/taiga/hooks/github/event_hooks.py
+++ b/taiga/hooks/github/event_hooks.py
@@ -157,7 +157,7 @@ class IssuesEventHook(BaseEventHook):
 
     def _process_labeled(self, user, github_url):
         issues = Issue.objects.filter(external_reference=["github", github_url])
-        l = list(self.payload.get('labels', []))
+        l = list(self.payload.labels)
 
         raise ActionSyntaxException(str(l))
 

--- a/taiga/hooks/github/event_hooks.py
+++ b/taiga/hooks/github/event_hooks.py
@@ -21,6 +21,7 @@ from taiga.projects.models import IssueStatus, TaskStatus, UserStoryStatus
 from taiga.projects.issues.models import Issue
 from taiga.projects.tasks.models import Task
 from taiga.projects.userstories.models import UserStory
+from taiga.projects.history.models import HistoryEntry
 from taiga.projects.history.services import take_snapshot
 from taiga.projects.notifications.services import send_notifications
 from taiga.hooks.event_hooks import BaseEventHook
@@ -131,25 +132,41 @@ class IssuesEventHook(BaseEventHook):
         project_url = self.payload.get('repository', {}).get('html_url', None)
         description = self.payload.get('issue', {}).get('body', None)
         description = replace_github_references(project_url, description)
+        state = self.payload.get('issue', {}).get('state', None)
 
         user = get_github_user(github_user_id)
 
         if not all([subject, github_url, project_url]):
             raise ActionSyntaxException(_("Invalid issue information"))
 
-        if self.payload.get('action', None) == "opened":
-            self._process_opened(number, subject, github_url, user, github_user_name, github_user_url, project_url, description)
         if self.payload.get('action', None) == "edited":
-            self._process_edited(number, subject, github_url, user, github_user_name, github_user_url, project_url, description)
+            self._process_edited(subject, github_url, description)
+        elif self.payload.get('action', None) == "closed":
+            self._process_status_changed(github_url, state)
+        elif self.payload.get('action', None) == "reopened":
+            self._process_status_changed(github_url, state)
+        elif self.payload.get('action', None) == "opened":
+            self._process_opened(number, subject, github_url, user, github_user_name, github_user_url, project_url, description)
+        else
+            raise ActionSyntaxException(_("Invalid issue information"))            
 
 
-    def _process_edited(self, number, subject, github_url, user, github_user_name, github_user_url, project_url, description):
+    def _process_edited(self, subject, github_url, description):
         issues = Issue.objects.filter(external_reference=["github", github_url])
 
         for item in list(issues):
             item.subject = subject
+            item.description = description
             item.save()
 
+
+    def _process_status_changed(self, github_url, status):
+        issues = Issue.objects.filter(external_reference=["github", github_url])
+
+        for item in list(issues):
+            item.status = IssueStatus.objects.get(project=self.project, slug=status)
+            item.save()
+            
 
     def _process_opened(self, number, subject, github_url, user, github_user_name, github_user_url, project_url, description):
         issue = Issue.objects.create(
@@ -185,8 +202,8 @@ class IssuesEventHook(BaseEventHook):
 
 class IssueCommentEventHook(BaseEventHook):
     def process_event(self):
-        if self.payload.get('action', None) != "created":
-            raise ActionSyntaxException(_("Invalid issue comment information"))
+        if self.payload.get('action', None) != "created" AND self.payload.get('action', None) != "edited":
+                raise ActionSyntaxException(_("Invalid issue comment information"))
 
         number = self.payload.get('issue', {}).get('number', None)
         subject = self.payload.get('issue', {}).get('title', None)
@@ -197,6 +214,7 @@ class IssueCommentEventHook(BaseEventHook):
         project_url = self.payload.get('repository', {}).get('html_url', None)
         comment_message = self.payload.get('comment', {}).get('body', None)
         comment_message = replace_github_references(project_url, comment_message)
+        comment_github_url = self.payload.get('comment', {}).get('html_url', None)
 
         user = get_github_user(github_user_id)
 
@@ -204,23 +222,39 @@ class IssueCommentEventHook(BaseEventHook):
             raise ActionSyntaxException(_("Invalid issue comment information"))
 
         issues = Issue.objects.filter(external_reference=["github", github_url])
-        tasks = Task.objects.filter(external_reference=["github", github_url])
-        uss = UserStory.objects.filter(external_reference=["github", github_url])
+        # tasks = Task.objects.filter(external_reference=["github", github_url])
+        # uss = UserStory.objects.filter(external_reference=["github", github_url])
 
-        for item in list(issues) + list(tasks) + list(uss):
-            if number and subject and github_user_name and github_user_url:
-                comment = _("Comment by [@{github_user_name}]({github_user_url} "
-                            "\"See @{github_user_name}'s GitHub profile\") "
-                            "from GitHub.\nOrigin GitHub issue: [gh#{number} - {subject}]({github_url} "
-                            "\"Go to 'gh#{number} - {subject}'\")\n\n"
-                            "{message}").format(github_user_name=github_user_name,
-                                                github_user_url=github_user_url,
-                                                number=number,
-                                                subject=subject,
-                                                github_url=github_url,
-                                                message=comment_message)
-            else:
-                comment = _("Comment From GitHub:\n\n{message}").format(message=comment_message)
+        if number and subject and github_user_name and github_user_url:
+            comment = _("Comment by [@{github_user_name}]({github_user_url} "
+                        "\"See @{github_user_name}'s GitHub profile\") "
+                        "from GitHub.\nOrigin GitHub comment: [gh#{number} - {subject}]({github_url} "
+                        "\"Go to 'gh#{number} - {subject}'\")\n\n"
+                        "{message}").format(github_user_name=github_user_name,
+                                            github_user_url=github_user_url,
+                                            number=number,
+                                            subject=subject,
+                                            github_url=comment_github_url,
+                                            message=comment_message)
+        else:
+            comment = _("Comment From GitHub:\n\n{message}").format(message=comment_message)
 
-            snapshot = take_snapshot(item, comment=comment, user=user)
-            send_notifications(item, history=snapshot)
+        for item in list(issues):# + list(tasks) + list(uss):
+            if self.payload.get('action', None) == "created":
+                self._process_created(item, comment, user)
+            elif self.payload.get('action', None) == "edited":
+                self._process_edited(item, comment, comment_github_url)
+
+
+    def _process_created(self, item, comment, user):
+        snapshot = take_snapshot(item, comment=comment, user=user)
+        send_notifications(item, history=snapshot)
+
+
+    def _process_edited(self, item, comment, comment_github_url):
+        histories = HistoryEntry.objects.filter(key="issues.issue:" + item.id, comment__contains=comment_github_url)
+        
+        for history in list(histories):
+            history.comment = comment
+            history.save()
+                

--- a/taiga/hooks/github/event_hooks.py
+++ b/taiga/hooks/github/event_hooks.py
@@ -157,8 +157,11 @@ class IssuesEventHook(BaseEventHook):
 
     def _process_labeled(self, user, github_url):
         issues = Issue.objects.filter(external_reference=["github", github_url])
-        
-        labels = [x['name'] for x in list(self.payload.get('labels', []))]
+        l = list(self.payload.get('labels', []))
+
+        raise ActionSyntaxException(str(l))
+
+        labels = [x['name'] for x in l]
 
         # (Testar) pesquisar os tipos dos issues pelo nome dos labels e trazer o primeiro ordenado pelo order crescente 
         issueType = IssueType.objects.filter(project=self.project, name__in=labels).order_by('order').first()

--- a/taiga/hooks/github/event_hooks.py
+++ b/taiga/hooks/github/event_hooks.py
@@ -163,7 +163,7 @@ class IssuesEventHook(BaseEventHook):
         # (Testar) pesquisar os tipos dos issues pelo nome dos labels e trazer o primeiro ordenado pelo order crescente 
         issueType = IssueType.objects.filter(project=self.project, name__in=labels).order_by('order').first()
 
-        print '\nIssuetype:' issueType.name
+        print '\nIssuetype:' + issueType.name
 
         print str(labels)
 

--- a/taiga/hooks/github/event_hooks.py
+++ b/taiga/hooks/github/event_hooks.py
@@ -165,10 +165,8 @@ class IssuesEventHook(BaseEventHook):
 
         # print ('\nIssuetype:' + issueType.name)
 
-        print (str(labels))
-
-        print (labels)
-
+        raise ActionSyntaxException(str(labels))            
+        
         print (str(issueType))
 
         print (issueType)

--- a/taiga/hooks/github/event_hooks.py
+++ b/taiga/hooks/github/event_hooks.py
@@ -147,8 +147,8 @@ class IssuesEventHook(BaseEventHook):
         issues = Issue.objects.filter(external_reference=["github", github_url])
 
         for item in list(issues):
-
-            return
+            item.subject = subject
+            item.save()
 
 
     def _process_opened(self, number, subject, github_url, user, github_user_name, github_user_url, project_url, description):

--- a/taiga/hooks/github/event_hooks.py
+++ b/taiga/hooks/github/event_hooks.py
@@ -158,7 +158,7 @@ class IssuesEventHook(BaseEventHook):
     def _process_labeled(self, user, github_url):
         issues = Issue.objects.filter(external_reference=["github", github_url])
         
-        raise ActionSyntaxException(str(self.payload))
+        l = self.payload.get('issue', {}).get('labels', [])
 
         labels = [x['name'] for x in l]
 
@@ -167,7 +167,7 @@ class IssuesEventHook(BaseEventHook):
 
         # print ('\nIssuetype:' + issueType.name)
 
-        raise ActionSyntaxException(str(labels))            
+        # raise ActionSyntaxException(str(labels))            
         
         print (str(issueType))
 

--- a/taiga/hooks/github/event_hooks.py
+++ b/taiga/hooks/github/event_hooks.py
@@ -138,7 +138,7 @@ class IssuesEventHook(BaseEventHook):
             raise ActionSyntaxException(_("Invalid issue information"))
 
         if self.payload.get('action', None) == "opened":
-            self._process_opened(self, number, subject, github_url, user, github_user_name, github_user_url, project_url, description)
+            self._process_opened(number, subject, github_url, user, github_user_name, github_user_url, project_url, description)
         if self.payload.get('action', None) == "edited":
             self._process_edited(number, subject, github_url, user, github_user_name, github_user_url, project_url, description)
 

--- a/taiga/hooks/github/event_hooks.py
+++ b/taiga/hooks/github/event_hooks.py
@@ -158,7 +158,7 @@ class IssuesEventHook(BaseEventHook):
     def _process_labeled(self, user, github_url):
         issues = Issue.objects.filter(external_reference=["github", github_url])
         
-        labels = [x.name for x in list(self.payload.get('labels', [])]
+        labels = [x.name for x in list(self.payload.get('labels', []))]
 
         # (Testar) pesquisar os tipos dos issues pelo nome dos labels e trazer o primeiro ordenado pelo order crescente 
         issueType = IssueType.objects.filter(project=self.project, name__in=labels).order_by('order').first()

--- a/taiga/hooks/github/event_hooks.py
+++ b/taiga/hooks/github/event_hooks.py
@@ -163,6 +163,12 @@ class IssuesEventHook(BaseEventHook):
         # (Testar) pesquisar os tipos dos issues pelo nome dos labels e trazer o primeiro ordenado pelo order crescente 
         issueType = IssueType.objects.filter(project=self.project, name__in=labels).order_by('order').first()
 
+        print '\nIssuetype:' issueType.name
+
+        print str(labels)
+
+        print labels
+
         for issue in list(issues):
             issue.tags = labels # pesquisar como salvar tags (Testar) 
             issue.type = issueType

--- a/taiga/hooks/github/event_hooks.py
+++ b/taiga/hooks/github/event_hooks.py
@@ -202,7 +202,7 @@ class IssuesEventHook(BaseEventHook):
 
 class IssueCommentEventHook(BaseEventHook):
     def process_event(self):
-        if self.payload.get('action', None) != "created" AND self.payload.get('action', None) != "edited":
+        if self.payload.get('action', None) != "created" and self.payload.get('action', None) != "edited":
                 raise ActionSyntaxException(_("Invalid issue comment information"))
 
         number = self.payload.get('issue', {}).get('number', None)

--- a/taiga/hooks/github/event_hooks.py
+++ b/taiga/hooks/github/event_hooks.py
@@ -157,9 +157,8 @@ class IssuesEventHook(BaseEventHook):
 
     def _process_labeled(self, user, github_url):
         issues = Issue.objects.filter(external_reference=["github", github_url])
-        l = list(self.payload['labels'])
-
-        raise ActionSyntaxException(str(l))
+        
+        raise ActionSyntaxException(str(self.payload))
 
         labels = [x['name'] for x in l]
 

--- a/taiga/hooks/github/event_hooks.py
+++ b/taiga/hooks/github/event_hooks.py
@@ -26,6 +26,7 @@ from taiga.projects.history.services import take_snapshot
 from taiga.projects.notifications.services import send_notifications
 from taiga.hooks.event_hooks import BaseEventHook
 from taiga.hooks.exceptions import ActionSyntaxException
+from taiga.mdrender.service import render as mdrender
 
 from .services import get_github_user
 
@@ -256,5 +257,5 @@ class IssueCommentEventHook(BaseEventHook):
         
         for history in list(histories):
             history.comment = comment
+            history.comment_html = mdrender(item.project, comment)
             history.save()
-                

--- a/taiga/hooks/github/event_hooks.py
+++ b/taiga/hooks/github/event_hooks.py
@@ -147,7 +147,7 @@ class IssuesEventHook(BaseEventHook):
             self._process_status_changed(github_url, state)
         elif self.payload.get('action', None) == "opened":
             self._process_opened(number, subject, github_url, user, github_user_name, github_user_url, project_url, description)
-        else
+        else:
             raise ActionSyntaxException(_("Invalid issue information"))            
 
 


### PR DESCRIPTION
At first, the integration with github only covered issues creation and comments creation.

This improvement covers:
- Issues edited and deleted
- Github issues labels changes taiga's tags and issue type (based on issues type order using same names)
- Issues status (uses github issue state and taiga's issues status slug)
- Comments edited and deleted
